### PR TITLE
Pull pgp into a separate module

### DIFF
--- a/src/daemons/event-subscriptions.js
+++ b/src/daemons/event-subscriptions.js
@@ -1,10 +1,10 @@
 const _ = require('lodash')
 const AWS = require('aws-sdk')
-const pgp = require('pg-promise')()
 
 const { batchWrite } = require('../utils/dynamodb-load')
+const database = require('../utils/database')
 
-const db = pgp(process.env.DATABASE_URL)
+const db = database.getConnection(process.env.DATABASE_URL)
 const dynamoDb = new AWS.DynamoDB.DocumentClient()
 
 module.exports.handler = (event, context, callback) => {

--- a/src/daemons/monitoring/index.js
+++ b/src/daemons/monitoring/index.js
@@ -1,8 +1,9 @@
 const AWS = require('aws-sdk')
-const pgp = require('pg-promise')()
 const moment = require('moment-timezone')
 
-const db = pgp(process.env.DATABASE_URL)
+const database = require('../utils/database')
+
+const db = database.getConnection(process.env.DATABASE_URL)
 const dynamoDb = new AWS.DynamoDB.DocumentClient()
 
 const extract = require('./extract')

--- a/src/utils/database.js
+++ b/src/utils/database.js
@@ -1,0 +1,3 @@
+const pgp = require('pg-promise')()
+
+module.exports.getConnection = pgp


### PR DESCRIPTION
Refactor database dependencies so they depend on a local module.
This module is more suitable for mocking for tests, compared to pgp